### PR TITLE
enable array behaviour for CARDINALITY_0_N

### DIFF
--- a/src/SchemaOrgModel/TypesGenerator.php
+++ b/src/SchemaOrgModel/TypesGenerator.php
@@ -250,6 +250,7 @@ class TypesGenerator
                     }
 
                     $isArray = in_array($cardinality, [
+                        CardinalitiesExtractor::CARDINALITY_0_N,
                         CardinalitiesExtractor::CARDINALITY_1_N,
                         CardinalitiesExtractor::CARDINALITY_N_N,
                     ]);


### PR DESCRIPTION
Shouldn't `0...*` cardinality also be an array?